### PR TITLE
fix: clean up existing swapfile before fallocate

### DIFF
--- a/.github/workflows/pi-gen.yml
+++ b/.github/workflows/pi-gen.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Set up swap space
         run: |
+          sudo swapoff /swapfile 2>/dev/null || true
+          sudo rm -f /swapfile
           sudo fallocate -l 4G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile


### PR DESCRIPTION
Prevents "Text file busy" error on GitHub Actions runners that already have an active /swapfile.